### PR TITLE
Dev 0.1.1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,3 +233,5 @@ export default function moxy(config?: {
 
   return moxyApi
 }
+
+export * from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,18 +178,22 @@ export default function moxy(config?: {
         server.close(() => resolve())
       })
     },
-    mocks: (path?: string) => {
-      return path ? mocks.filter((mock) => mock.path === path) : mocks
+    mocks: <ResData>(path?: string): Mock<ResData>[] => {
+      let myMocks = mocks as Mock<ResData>[]
+      if (path) {
+        myMocks = myMocks.filter(mock => mock.path === path)
+      }
+      return myMocks
     },
     log: <ReqData, ResData>(path?: string, method?: HTTPMethod) => {
-      let log = requestLog
+      let log = requestLog as LoggedRequest<ReqData, ResData>[]
       if (path) {
         log = log.filter((entry) => entry.path === path)
       }
       if (method) {
         log = log.filter((entry) => entry.method.toLowerCase() === method)
       }
-      return log as LoggedRequest<ReqData, ResData>[]
+      return log
     },
     clearLog: () => {
       requestLog = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export default function moxy(config?: {
     mocks: (path?: string) => {
       return path ? mocks.filter((mock) => mock.path === path) : mocks
     },
-    log: (path?: string, method?: HTTPMethod) => {
+    log: <ReqData, ResData>(path?: string, method?: HTTPMethod) => {
       let log = requestLog
       if (path) {
         log = log.filter((entry) => entry.path === path)
@@ -189,7 +189,7 @@ export default function moxy(config?: {
       if (method) {
         log = log.filter((entry) => entry.method.toLowerCase() === method)
       }
-      return log
+      return log as LoggedRequest<ReqData, ResData>[]
     },
     clearLog: () => {
       requestLog = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,9 +18,12 @@ export type HTTPHeaders =
 export interface Moxy {
   start: () => Server
   stop: () => Promise<void>
-  mocks: (path?: string) => Mock[]
-  log: <G = unknown, T = unknown>(path?: string, method?: HTTPMethod) => LoggedRequest<G, T>[]
+  mocks: <G>(path?: string) => Mock<G>[]
   clearLog: () => void
+  log: <G = unknown, T = unknown>(
+    path?: string,
+    method?: HTTPMethod
+  ) => LoggedRequest<G, T>[]
   setMock: <G>(
     path: string,
     method?: HTTPMethod,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface Moxy {
   start: () => Server
   stop: () => Promise<void>
   mocks: (path?: string) => Mock[]
-  log: (path?: string, method?: HTTPMethod) => Log['log']
+  log: <G = unknown, T = unknown>(path?: string, method?: HTTPMethod) => LoggedRequest<G, T>[]
   clearLog: () => void
   setMock: <G>(
     path: string,


### PR DESCRIPTION
Changes:
* Exports types from `index`, so that a developer can access types like this `const moxy, { Mock, HTTPHeaders } from 'moxy';`
* Adds type coercion to `mocks()` and `log()`. 
  - A developer can pass a generic to the function which will then cause their typescript environment to assume all mocks or logs returned will have that shape of data for the Request or Response data.
  - This is useful when you are testing, you can type coerce using the genetic rather than use `const mock = mocks()[0] as Mock<{title: string}>`